### PR TITLE
run no-response workflow once a day only

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -7,7 +7,7 @@ on:
     types: [created]
   schedule:
     # Schedule for five minutes after the hour, every hour
-    - cron: '5 * * * *'
+    - cron: '0 0 * * *'
 
 # By specifying the access of one of the scopes, all of those that are not
 # specified are set to 'none'.


### PR DESCRIPTION
avoids some API ratelimit